### PR TITLE
feat(android): set `MODE_IN_COMMUNICATION` when getting user audio

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -325,6 +325,10 @@ class GetUserMediaImpl {
     }
 
     private AudioTrack getUserAudio(ConstraintsMap constraints) {
+        // https://github.com/flutter-webrtc/flutter-webrtc/issues/809#issuecomment-994607194.
+        AudioManager audioManager = (AudioManager) applicationContext.getSystemService(Context.AUDIO_SERVICE);
+        audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+
         MediaConstraints audioConstraints;
         if (constraints.getType("audio") == ObjectType.Boolean) {
             audioConstraints = new MediaConstraints();

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -17,6 +17,7 @@ import android.hardware.camera2.CameraDevice;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
 import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
 import android.media.projection.MediaProjection;
 import android.media.projection.MediaProjectionManager;
 import android.os.Build;


### PR DESCRIPTION
Based on the recommendation from https://github.com/flutter-webrtc/flutter-webrtc/issues/809#issuecomment-994607194, this sets the mode to [`MODE_IN_COMMUNICATION`](https://developer.android.com/reference/android/media/AudioManager#MODE_IN_COMMUNICATION) when getting user audio.

This recommendation can also be found at https://stackoverflow.com/a/64065237. 